### PR TITLE
support numpy like concaternate

### DIFF
--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -86,6 +86,9 @@ def from_list(examples, immutable_warranty='pickle'):
 def concatenate(*datasets):
     """Create a new Dataset by concatenation of all passed datasets.
 
+    concatenate(ds1, ds2, ...)
+    concatenate((ds1, ds2, ...))
+
     Args:
         datasets: List of datasets. Must be
     Returns: Concatenation of all input datasets.
@@ -93,6 +96,8 @@ def concatenate(*datasets):
     """
     if len(datasets) == 0:
         raise ValueError('Need at least one dataset to concatenate!')
+    if len(datasets) == 1 and isinstance(datasets[0], (tuple, list)):
+        datasets, = datasets
     if not all(isinstance(dataset, Dataset) for dataset in datasets):
         raise TypeError('All input arguments must be datasets!')
     if len(datasets) == 1:
@@ -315,6 +320,9 @@ class Dataset:
         """
         Concatenate this dataset with others. keys need to be unambiguous.
 
+        concatenate(self, ds1, ds2, ...)
+        concatenate(self, (ds1, ds2, ...))
+
         Args:
             *others: list of datasets to be concatenated
 
@@ -324,6 +332,8 @@ class Dataset:
         """
         if len(others) == 0:
             return self
+        if len(others) == 1 and isinstance(others[0], (tuple, list)):
+            others, = others
         return ConcatenateDataset(self, *others)
 
     def zip(self, *others):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -129,6 +129,16 @@ def test_concatenate_function():
     assert ds[-1]['example_id'] == 'example_id_5'
     assert ds[:1][0]['example_id'] == 'example_id_1'
 
+    ds = lazy_dataset.concatenate([ds_train, ds_predict])
+    example_ids = [e['example_id'] for e in ds]
+    assert example_ids == [f'example_id_{i}' for i in range(1, 6)]
+
+    assert ds['example_id_1']['example_id'] == 'example_id_1'
+    assert ds['example_id_5']['example_id'] == 'example_id_5'
+    assert ds[0]['example_id'] == 'example_id_1'
+    assert ds[-1]['example_id'] == 'example_id_5'
+    assert ds[:1][0]['example_id'] == 'example_id_1'
+
 
 def test_concatenate_function_raises_on_empty_list():
     with pytest.raises(ValueError):
@@ -147,6 +157,16 @@ def test_concatenate():
     ds_predict = get_dataset_predict()
 
     ds = ds_train.concatenate(ds_predict)
+    example_ids = [e['example_id'] for e in ds]
+    assert example_ids == [f'example_id_{i}' for i in range(1, 6)]
+
+    assert ds['example_id_1']['example_id'] == 'example_id_1'
+    assert ds['example_id_5']['example_id'] == 'example_id_5'
+    assert ds[0]['example_id'] == 'example_id_1'
+    assert ds[-1]['example_id'] == 'example_id_5'
+    assert ds[:1][0]['example_id'] == 'example_id_1'
+
+    ds = ds_train.concatenate([ds_predict])
     example_ids = [e['example_id'] for e in ds]
     assert example_ids == [f'example_id_{i}' for i in range(1, 6)]
 


### PR DESCRIPTION
In #10 was mentioned that `numpy.concaternate` supports list as input (`np.concaternate((a1, a2, ...), **kwargs)`) instead of `np.concaternate(a1, a2, ..., **kwargs)`. This PR adds support for that style as input.