### PR TITLE
introduce indexable and delete ShuffleDataset

### DIFF
--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -5,13 +5,12 @@ import textwrap
 import operator
 from copy import deepcopy
 import itertools
-import random as rnd
+import random
+import collections
 
 import numpy as np
 
 LOG = logging.getLogger('lazy_dataset')
-
-import collections
 
 
 def new(examples, immutable_warranty='pickle'):
@@ -1124,7 +1123,7 @@ class LocalShuffleDataset(Dataset):
                     print('Shuffle Buffer filled.')
                     buffer_filled = True
                 yield buffer.pop(int(np.random.choice(self.buffer_size)))
-        rnd.shuffle(buffer)
+        random.shuffle(buffer)
         for element in buffer:
             yield element
 

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -148,7 +148,8 @@ class Dataset:
             return SliceDataset(item, self)
         elif isinstance(item, bytes):
             raise NotImplementedError(
-                f'This is not implemented for an bytes objext. Use bytes.decode() to convert it to an str.\n'
+                f'This is not implemented for an bytes objext. '
+                f'Use bytes.decode() to convert it to an str.\n'
                 f'__getitem__ is not implemented for {self.__class__}[{item!r}],\n'
                 f'where type({item!r}) == {type(item)} '
                 f'self: \n{self!r}'
@@ -403,6 +404,8 @@ class Dataset:
                 If True, shuffle on each iteration, but disable indexing.
                 If False, single shuffle, but support indexing.
             rng:
+                instance of np.random.RandomState.
+                When None, fallback to np.random.
             buffer_size:
 
         Returns:
@@ -509,7 +512,7 @@ class Dataset:
                 f'split into {sections} sections.'
             )
         slices = np.array_split(np.arange(len(self)), sections)
-        return [self[list(s)] for s in slices]
+        return [self[s] for s in slices]
 
     def sort(self, key_fn=None, sort_fn=sorted, reverse=False):
         """
@@ -1062,13 +1065,15 @@ class ReShuffleDataset(Dataset):
     def __getitem__(self, item):
         if isinstance(item, str):
             return self.input_dataset[item]
-        elif isinstance(item, (numbers.Integral, slice, tuple, list)):
+        elif isinstance(item, numbers.Integral):
             raise TypeError(
                 f'{self.__class__.__name__} does not support '
-                f'integers and slices as argument of __getitem__.'
+                f'integers as argument of __getitem__.'
                 f'Got argument "{item}" of type {type(item)}.'
             )
         else:
+            # Let super().__getitem__(...) raise the Exception when item is a
+            # slice, tuple or list.
             return super().__getitem__(item)
 
 

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -527,9 +527,9 @@ class Dataset:
         >>> it_sorted = it.sort(lambda ex: ex['x'])
         >>> it_sorted
           DictDataset(len=4)
-        SliceDataset(['a', 'd', 'b', 'c'])
+        SliceDataset([0, 3, 1, 2])
         >>> print(it_sorted.slice)
-        (0, 3, 1, 2)
+        [0 3 1 2]
         >>> dict(it_sorted)
         {'a': {'x': 1}, 'd': {'x': 2}, 'b': {'x': 3}, 'c': {'x': 12}}
 
@@ -545,15 +545,15 @@ class Dataset:
         if key_fn is None:
             sort_order = sort_fn(self.keys())
         else:
-            sort_values = [key_fn(self[key]) for key in self.keys()]
+            sort_values = [key_fn(example) for example in self]
             sort_order = [
-                key
-                for _, key in sort_fn(
-                    zip(sort_values, self.keys()),
+                index
+                for _, index in sort_fn(
+                    zip(sort_values, itertools.count()),
                     reverse=reverse,
                 )
             ]
-        return self[tuple(sort_order)]
+        return self[sort_order]
 
     def shard(self, num_shards, shard_index):
         """

--- a/tests/test_shuffle_prefetch.py
+++ b/tests/test_shuffle_prefetch.py
@@ -36,14 +36,24 @@ def test_shuffle_prefetch():
     example_ids = [ex['example_id'] for ex in ds]
     assert example_ids == 'c b e a d'.split()
 
-    np.random.seed(0)
-
+    rng = np.random.RandomState(1)
     # With reshuffle prefetch still works and the ordering is each time
     # different
     ds = get_dataset()
-    ds = ds.shuffle(reshuffle=True)
+    ds = ds.shuffle(rng=rng, reshuffle=True)
     ds = ds.prefetch(2, 4)
     example_ids = [ex['example_id'] for ex in ds]
-    assert example_ids == 'c a b d e'.split()
+    assert example_ids == 'c b e a d'.split()
     example_ids = [ex['example_id'] for ex in ds]
-    assert example_ids == 'a c b e d'.split()
+    assert example_ids == 'c e d a b'.split()
+
+
+def test_reshuffle_slice():
+    rng = np.random.RandomState(1)
+
+    ds = get_dataset()
+    ds = ds.shuffle(rng=rng, reshuffle=True)
+    ds = ds.map(lambda x: x)
+
+    with pytest.raises(RuntimeError):
+        ds = ds[:3]


### PR DESCRIPTION
The ListDataset does not have keys. The keys were used in the past to figure out if a Dataset is indexable.
Now the Dataset has the property indexable to indicate if the dataset is indexable.
Sort now uses indices instead of keys.

I deleted the ShuffleDataset, because can be replaced with the SliceDataset.