### PR TITLE
extend DynamicBucketDataset and add methods for bucketing

### DIFF
--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -769,19 +769,30 @@ class Dataset:
     def batch_bucket_dynamic(
             self, batch_size, key, max_padding_rate, total_size_threshold=None,
             expiration=None, drop_incomplete=False, sort_by_key=False):
-        """batch dynamically spawned and filled buckets
-
+        """dynamically spawn and gather examples into buckets.
+        
+        Note that this operation is work in progress
+        
         Args:
-            batch_size:
-            key:
-            max_padding_rate:
-            total_size_threshold:
-            expiration:
-            drop_incomplete:
-            sort_by_key:
-
-        Returns:
-
+            input_dataset:
+            batch_size: max batch_size (can be smaller if expiration or
+                max_total_size is set)
+            key: callable or dict key returning a scalar length given an
+                example dict
+            max_padding_rate: the maximum padding that has to be added to a
+                signal in a bucket. E.g. if set to 0.2, a example of length 100
+                can only be in a bucket with examples with lengths from 80 to 125.
+            total_size_threshold: total size of a bucket (len(bucket)*max_length_in_bucket)
+                after which a bucket is emitted though len(bucket) < batch_size
+            expiration: maximum life time of a bucket. After this number of
+                subsequently yielded batches it is either emitted
+                (if drop_incomplete is False) or discarded
+            drop_incomplete: if True drop incomplete buckets at the end of
+                iteration or when buckets expire, else emit them.
+            sort_by_key: if True reversely sorts the bucket by the lengths of
+                the examples before emitting. This simplifies getting the
+                maximum length of the bucket (e.g. pytorchs PackedSequence
+                requires reversely sorted batches).
         """
         return DynamicBucketDataset(
             self,

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -578,7 +578,7 @@ class Dataset:
         return BatchDataset(self, batch_size, drop_last)
 
     def batch_bucket_dynamic(
-            self, batch_size, key, max_padding_rate, max_total_size=None,
+            self, batch_size, key, max_padding_rate, total_size_threshold=None,
             expiration=None, drop_incomplete=False, sort_by_key=False):
         """batch dynamically spawned and filled buckets
 
@@ -586,7 +586,7 @@ class Dataset:
             batch_size:
             key:
             max_padding_rate:
-            max_total_size:
+            total_size_threshold:
             expiration:
             drop_incomplete:
             sort_by_key:
@@ -599,7 +599,7 @@ class Dataset:
             batch_size=batch_size,
             key=key,
             max_padding_rate=max_padding_rate,
-            total_size_threshold=max_total_size,
+            total_size_threshold=total_size_threshold,
             expiration=expiration,
             drop_incomplete=drop_incomplete,
             sort_by_key=sort_by_key
@@ -1677,7 +1677,7 @@ class DynamicBucketDataset(Dataset):
         else:
             raise ValueError(key)
         self.max_padding_rate = max_padding_rate
-        self.max_total_size = total_size_threshold
+        self.total_size_threshold = total_size_threshold
         self.expiration = expiration
         self.drop_incomplete = drop_incomplete
         self.sort_by_key = sort_by_key
@@ -1688,7 +1688,7 @@ class DynamicBucketDataset(Dataset):
             batch_size=self.batch_size,
             key=self.key,
             max_padding_rate=self.max_padding_rate,
-            drop_last=self.drop_incomplete,
+            drop_incomplete=self.drop_incomplete,
         )
 
     @property
@@ -1709,8 +1709,8 @@ class DynamicBucketDataset(Dataset):
                     if (
                         len(bucket) >= self.batch_size
                         or (
-                            self.max_total_size is not None
-                            and (len(bucket) * max_value) > self.max_total_size
+                            self.total_size_threshold is not None
+                            and (len(bucket) * max_value) > self.total_size_threshold
                         )
                     ):
                         if self.sort_by_key:

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -660,7 +660,7 @@ class Dataset:
             batch_size=batch_size,
             key=key,
             max_padding_rate=max_padding_rate,
-            max_total_size=max_total_size,
+            total_size_threshold=max_total_size,
             expiration=expiration,
             drop_incomplete=drop_incomplete,
             sort_by_key=sort_by_key
@@ -1702,7 +1702,7 @@ class DynamicBucketDataset(Dataset):
     """
     def __init__(
             self, input_dataset, batch_size, key, max_padding_rate,
-            max_total_size=None, expiration=None, drop_incomplete=False,
+            total_size_threshold=None, expiration=None, drop_incomplete=False,
             sort_by_key=False
     ):
         """dynamically spawn and gather examples into buckets.
@@ -1717,7 +1717,7 @@ class DynamicBucketDataset(Dataset):
             max_padding_rate: the maximum padding that has to be added to a
                 signal in a bucket. E.g. if set to 0.2, a example of length 100
                 can only be in a bucket with examples with lengths from 80 to 125.
-            max_total_size: total size of a bucket (len(bucket)*max_length_in_bucket)
+            total_size_threshold: total size of a bucket (len(bucket)*max_length_in_bucket)
                 after which a bucket is emitted though len(bucket) < batch_size
             expiration: maximum life time of a bucket. After this number of
                 steps it is either emitted (if drop_incomplete is False)
@@ -1736,7 +1736,7 @@ class DynamicBucketDataset(Dataset):
         else:
             raise ValueError(key)
         self.max_padding_rate = max_padding_rate
-        self.max_total_size = max_total_size
+        self.max_total_size = total_size_threshold
         self.expiration = expiration
         self.drop_incomplete = drop_incomplete
         self.sort_by_key = sort_by_key

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -1779,8 +1779,9 @@ class DynamicBucketDataset(Dataset):
                     ):
                         if self.sort_by_key:
                             bucket = sorted(bucket, key=self.key, reverse=True)
-                        batch_count += 1
                         yield bucket
+                        batch_count += 1
+                        buckets.pop(j)
                     else:
                         lower_bound = max(
                             lower_bound, value * (1 - self.max_padding_rate)
@@ -1794,9 +1795,7 @@ class DynamicBucketDataset(Dataset):
                         )
                     found_bucket = True
                     break
-            if found_bucket:
-                buckets.pop(j)
-            else:
+            if not found_bucket:
                 buckets.append((
                     [example],
                     batch_count,

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,0 +1,32 @@
+import lazy_dataset
+import numpy as np
+
+
+def test_bucket_idx():
+    examples = list(range(10))
+    ds = lazy_dataset.new(examples)
+    idx = ds.get_bucket_indices(lambda x: x, 5)
+    assert (idx == np.repeat(list(range(5)), 2)).all()
+
+
+def test_bucket():
+    examples = [1, 10, 5, 7, 8, 2, 4, 3, 20, 1, 6, 9]
+    ds = lazy_dataset.new(examples)
+
+    idx = ds.get_bucket_indices(key=lambda x: x, num_buckets=3)
+    buckets = [list(bucket) for bucket in ds.bucket(idx)]
+    assert buckets == [
+        [1, 2, 3, 1],
+        [5, 7, 4, 6],
+        [10, 8, 20, 9]
+    ]
+
+    batched_buckets = list(ds.batch_bucket(bucket_indices=idx, batch_size=2))
+    assert batched_buckets == [[1, 2], [3, 1], [5, 7], [4, 6], [10, 8], [20, 9]]
+
+    dynamic_batched_buckets = list(ds.batch_bucket_dynamic(
+        batch_size=2, key=lambda x: x, max_padding_rate=0.5
+    ))
+    assert dynamic_batched_buckets == [
+        [10, 5], [7, 8], [1, 2], [4, 3], [6, 9], [20], [1]
+    ]

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,30 +1,10 @@
 import lazy_dataset
-import numpy as np
-
-
-def test_bucket_idx():
-    examples = list(range(10))
-    examples = {str(j): i for j, i in enumerate(examples)}
-    ds = lazy_dataset.new(examples)
-    idx = list(ds.get_bucket_indices(lambda x: x, 5).values())
-    assert (np.array(idx) == np.repeat(list(range(5)), 2)).all()
 
 
 def test_bucket():
     examples = [1, 10, 5, 7, 8, 2, 4, 3, 20, 1, 6, 9]
     examples = {str(j): i for j, i in enumerate(examples)}
     ds = lazy_dataset.new(examples)
-
-    idx = ds.get_bucket_indices(lambda x: x, 3)
-    buckets = [list(bucket) for bucket in ds.bucket(idx)]
-    assert buckets == [
-        [1, 2, 3, 1],
-        [5, 7, 4, 6],
-        [10, 8, 20, 9]
-    ]
-
-    batched_buckets = list(ds.batch_bucket(bucket_indices=idx, batch_size=2))
-    assert batched_buckets == [[1, 2], [3, 1], [5, 7], [4, 6], [10, 8], [20, 9]]
 
     dynamic_batched_buckets = list(ds.batch_bucket_dynamic(
         batch_size=2, key=lambda x: x, max_padding_rate=0.5

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -4,16 +4,18 @@ import numpy as np
 
 def test_bucket_idx():
     examples = list(range(10))
+    examples = {str(j): i for j, i in enumerate(examples)}
     ds = lazy_dataset.new(examples)
-    idx = ds.get_bucket_indices(lambda x: x, 5)
-    assert (idx == np.repeat(list(range(5)), 2)).all()
+    idx = list(ds.get_bucket_indices(lambda x: x, 5).values())
+    assert (np.array(idx) == np.repeat(list(range(5)), 2)).all()
 
 
 def test_bucket():
     examples = [1, 10, 5, 7, 8, 2, 4, 3, 20, 1, 6, 9]
+    examples = {str(j): i for j, i in enumerate(examples)}
     ds = lazy_dataset.new(examples)
 
-    idx = ds.get_bucket_indices(key=lambda x: x, num_buckets=3)
+    idx = ds.get_bucket_indices(lambda x: x, 3)
     buckets = [list(bucket) for bucket in ds.bucket(idx)]
     assert buckets == [
         [1, 2, 3, 1],


### PR DESCRIPTION
add argument total_size_threshold to DynamicBucketDataset allowing to have a smaller batch_size for long sequences (this can be useful to not exceed gpu memory). Added methods for (dynamic and precomputed) bucketing.