### PR TITLE
rename it (iterator) to ds (dataset)

### DIFF
--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -910,6 +910,15 @@ class Dataset:
 
         Returns:
             Dataset of batches (lists of elements)
+
+        Example:
+            >>> examples = {'a': {'x': 1}, 'b': {'x': 3},  'c': {'x': 12}}
+            >>> ds = DictDataset(examples)#.shuffle(reshuffle=True)
+            >>> ds = ds.batch(2)
+            >>> for ex in ds:
+            ...     print(ex)
+            [{'x': 1}, {'x': 3}]
+            [{'x': 12}]
         """
         return BatchDataset(self, batch_size, drop_last)
 

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -420,7 +420,7 @@ class Dataset:
                 and the element that raised the exception while processing is
                 dropped. This can also be set to a specific type (or a list of
                 types) of exceptions to catch. If this is set to a value that
-                evaluates to `True`, the resulting iterator does not have a
+                evaluates to `True`, the resulting dataset does not have a
                 length.
 
         Returns:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -83,8 +83,8 @@ def test_map():
         d['example_id'] = d['example_id'].upper()
         return d
 
-    iterator = ds.map(map_fn)
-    example_ids = [e['example_id'] for e in iterator]
+    ds = ds.map(map_fn)
+    example_ids = [e['example_id'] for e in ds]
     assert example_ids == 'EXAMPLE_ID_1 EXAMPLE_ID_2 EXAMPLE_ID_3'.split()
 
     # Getitem should still be supported
@@ -97,8 +97,8 @@ def test_filter():
     def filter_fn(d):
         return not d['example_id'] == 'example_id_2'
 
-    iterator = ds.filter(filter_fn)
-    example_ids = [e['example_id'] for e in iterator]
+    ds = ds.filter(filter_fn)
+    example_ids = [e['example_id'] for e in ds]
     assert example_ids == 'example_id_1 example_id_3'.split()
 
     # Getitem with str should be supported
@@ -106,13 +106,13 @@ def test_filter():
 
     # Getitem with filtered str should fail
     with pytest.raises(IndexError):
-        _ = iterator['example_id_2']
+        _ = ds['example_id_2']
 
     # Getitem with int is not supported
     with pytest.raises(AssertionError):
-        _ = iterator[0]
+        _ = ds[0]
     with pytest.raises(AssertionError):
-        _ = iterator[:1]
+        _ = ds[:1]
 
 
 def test_concatenate_function():


### PR DESCRIPTION
Renaming some old code parts that still used it (iterator) instead of ds (dataset).

I used the following convention:
 - The API should never contain an abbreviation (Already the case).
 - The source code should usually use the full form.
 - The doctest examples usually use the abbreviation:
   - In the doctest it should be obvious what is meant.
   - With the full form, the lines get too long
 - In list comprehensions, the abbreviation increases the distinguishes between the element and the list.
