### PR TITLE
Fix name type bug

### DIFF
--- a/lazy_dataset/database.py
+++ b/lazy_dataset/database.py
@@ -1,6 +1,7 @@
 import json
 import weakref
 from pathlib import Path
+import typing
 
 import lazy_dataset
 
@@ -160,9 +161,16 @@ class Database:
                 f'Missing dataset_name, use e.g.: {self.dataset_names}'
             )
 
-        if isinstance(name, (tuple, list)):
+        if isinstance(name, str):
+            pass
+        elif isinstance(name, typing.Iterable) and not isinstance(name, dict):
             datasets = [self.get_dataset(n) for n in name]
             return lazy_dataset.concatenate(*datasets)
+        else:
+            raise TypeError(
+                'Argument type {type(name)} of {name} is not allowed!'
+                'Expected are str, list or tuple.'
+            )
 
         # Resulting dataset is immutable anyway due to pickle in
         # `lazy_dataset.from_dict`. This code here avoids to store the

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -23,6 +23,20 @@ class DatasetTest(unittest.TestCase):
         # dump_json(self.json, self.json_path)
         self.db = DictDatabase(self.json)
 
+    def test_get_dataset_allowed_argument_types_pass(self):
+        for name in (
+                'train',
+                ['train', 'test'],
+                (a for a in ['train', 'test']),
+                {'train': None, 'test': None}.keys(),
+        ):
+                _ = self.db.get_dataset(name)
+
+    def test_get_dataset_forbidden_argument_type_raise_type_error(self):
+        for name in (dict(a='b'), 3, None):
+            with self.assertRaises(TypeError):
+                _ = self.db.get_dataset(name)
+
     def test_dataset_names(self):
         self.assertListEqual(
             list(self.db.dataset_names),


### PR DESCRIPTION
This PR allows the use of e.g. a KeysView object to be used as argument for Database.get_dataset.