### PR TITLE
 enable doctests, add name argument and fix ReShuffleDataset with random state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install -e .
 
 script:
-  - pytest --doctest-modules tests/
+  - pytest --doctest-modules tests/ lazy_dataset/
 
 env:
   - OMP_NUM_THREADS=1 MKL_NUM_THREADS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ python:
 cache: pip
 
 install:
-  - pip install codecov
+  - pip install pytest coverage pytest-cov
+  - pip install codecov  # https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci
   - pip install -e .
 
 script:
-  - pytest --doctest-modules tests/ lazy_dataset/
+  - pytest --doctest-modules tests/ lazy_dataset/ --cov=lazy_dataset
+
+after_success:
+  - codecov # submit coverage
 
 env:
   - OMP_NUM_THREADS=1 MKL_NUM_THREADS=1

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -1503,13 +1503,17 @@ class ReShuffleDataset(Dataset):
     """
 
     def __init__(self, input_dataset, rng=np.random):
-        self.permutation = np.arange(len(input_dataset))
+        self._permutation = np.arange(len(input_dataset))
         self.input_dataset = input_dataset
         self.rng = rng
 
+    @property
+    def permutation(self):
+        self.rng.shuffle(self._permutation)
+        return self._permutation
+
     def copy(self, freeze=False):
         if freeze:
-            self.rng.shuffle(self.permutation)
             return self.input_dataset.copy(freeze=freeze)[self.permutation]
         else:
             return self.__class__(
@@ -1530,7 +1534,6 @@ class ReShuffleDataset(Dataset):
     #     return frozenset(self.input_dataset.keys())
 
     def __iter__(self):
-        np.random.shuffle(self.permutation)
         for idx in self.permutation:
             yield self.input_dataset[idx]
 

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -781,7 +781,6 @@ class Dataset:
             elements that were mapped to the this group ID by `group_fn`
 
         Example:
-            >>> from IPython.lib.pretty import pprint
             >>> examples = {'a': {'z': 1}, 'b': {'z': 2}, 'c': {'z': 1}, 'd': {'z': 1}, 'e': {'z': 3}}
             >>> ds = DictDataset(examples)
             >>> for k, v in ds.groupby(lambda ex: ex['z']).items():

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -27,7 +27,7 @@ def new(
         examples: The data to create a new dataset from
         immutable_warranty: How to ensure immutability. Available options are
             'pickle' and 'copy'.
-        name: An optional name for the dataset. Only effects the representer.
+        name: An optional name for the dataset. Only affects the representer.
 
     Returns:
         The `Dataset` created from `examples`
@@ -38,7 +38,7 @@ def new(
         >>> import lazy_dataset
         >>> ds = lazy_dataset.new({'a': 1, 'b': 2, 'c': 3}, name='MyDataset')
         >>> ds
-          DictDataset(name=MyDataset, len=3)
+          DictDataset(name='MyDataset', len=3)
         MapDataset(_pickle.loads)
         >>> ds.keys()
         ('a', 'b', 'c')
@@ -51,7 +51,7 @@ def new(
         >>> list(ds)
         [4, 6]
         >>> ds  # doctest: +ELLIPSIS
-              DictDataset(name=MyDataset, len=3)
+              DictDataset(name='MyDataset', len=3)
             MapDataset(_pickle.loads)
           MapDataset(<function <lambda> at ...>)
         FilterDataset(<function <lambda> at ...>)
@@ -1156,7 +1156,7 @@ class DictDataset(Dataset):
             return f'{self.__class__.__name__}(len={len(self)})'
         else:
             return f'{self.__class__.__name__}' \
-                   f'(name={self.name}, len={len(self)})'
+                   f'(name={self.name!r}, len={len(self)})'
 
     def keys(self):
         return self._keys

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -1324,6 +1324,7 @@ class ParMapDataset(MapDataset):
 
 class CatchExceptionDataset(Dataset):
     """
+    >>> from lazy_dataset.core import DictDataset, FilterException
     >>> ds = DictDataset({'a': 1, 'b': 2, 'c': 3})
     >>> list(ds)
     [1, 2, 3]
@@ -1335,13 +1336,13 @@ class CatchExceptionDataset(Dataset):
     >>> list(ds.map(foo))
     Traceback (most recent call last):
     ...
-    core.FilterException: Exception msg
+    lazy_dataset.core.FilterException: Exception msg
     >>> list(ds.map(foo).catch())
     [1, 3]
     >>> ds.map(foo).catch()[0]  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    NotImplementedError: __getitem__ is not well defined for <class 'core.CatchExceptionDataset'>[0],
+    NotImplementedError: __getitem__ is not well defined for <class 'lazy_dataset.core.CatchExceptionDataset'>[0],
     because 0 is an index
     self:
         DictDataset(len=3)
@@ -1984,6 +1985,7 @@ class KeyZipDataset(Dataset):
 class BatchDataset(Dataset):
     """
 
+    >>> from lazy_dataset.core import DictDataset
     >>> import string
     >>> examples = {c: i for i, c in enumerate(string.ascii_letters[:7])}
     >>> ds = DictDataset(examples)
@@ -2014,7 +2016,7 @@ class BatchDataset(Dataset):
     >>> ds['abc']
     Traceback (most recent call last):
     ...
-    NotImplementedError: __getitem__ is not implemented for <class 'core.BatchDataset'>['abc'],
+    NotImplementedError: __getitem__ is not implemented for <class 'lazy_dataset.core.BatchDataset'>['abc'],
     where type('abc') == <class 'str'>
     self:
         DictDataset(len=7)

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -219,21 +219,21 @@ def key_zip(*datasets):
         >>> import lazy_dataset
         >>> ds1 = lazy_dataset.new({'1': 1, '2': 2, '3': 3, '4': 4})
         >>> ds2 = lazy_dataset.new({'1': 5, '2': 6, '3': 7, '4': 8})
-        >>> key_zip(ds1, ds2)
+        >>> lazy_dataset.key_zip(ds1, ds2)
             DictDataset(len=4)
           MapDataset(_pickle.loads)
             DictDataset(len=4)
           MapDataset(_pickle.loads)
         KeyZipDataset()
 
-        >>> key_zip((ds1, ds2))
+        >>> lazy_dataset.key_zip((ds1, ds2))
             DictDataset(len=4)
           MapDataset(_pickle.loads)
             DictDataset(len=4)
           MapDataset(_pickle.loads)
         KeyZipDataset()
 
-        >>> list(key_zip(ds1, ds2))
+        >>> list(lazy_dataset.key_zip(ds1, ds2))
         [(1, 5), (2, 6), (3, 7), (4, 8)]
 
     Args:

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -1064,6 +1064,11 @@ class Dataset:
         Draws random samples from the dataset using the random number generator
         `rng_state`.
 
+        Returns a random element of the dataset when size is None.
+        When size is an integer, a random sub dataset is returned.
+        Iterating two times over this dataset returns the same elements.
+
+
         Args:
             size: Size of the result. Must be smaller then `len(datset)` if
                 `replace=False`.

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -1412,7 +1412,8 @@ class PrefetchDataset(Dataset):
         except Exception:
             raise RuntimeError(
                 'You can only use Prefetch if the incoming dataset is '
-                'indexable.'
+                'indexable.\n'
+                f'input_dataset:\n{input_dataset!r}'
             )
         assert num_workers >= 1, num_workers
         assert buffer_size >= num_workers, (num_workers, buffer_size)

--- a/lazy_dataset/database.py
+++ b/lazy_dataset/database.py
@@ -182,7 +182,7 @@ class Database:
             pass
 
         examples = self.get_examples(name)
-        ds = lazy_dataset.from_dict(examples)
+        ds = lazy_dataset.from_dict(examples, name=name)
 
         self._dataset_weak_ref_dict[name] = ds
 


### PR DESCRIPTION
 - enable doctests in travis
 - add name argument to new, from_dict and from_list
 - use `rng` in `__iter__` of `ReShuffleDataset`
 - fix doctests for travis