### PR TITLE
Add DiskCacheDataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Supported transformations:
  - `dataset.sort(key_fn, sort_fn=sorted)`: Sorts the examples depending on the values `key_fn(example)` ([list.sort](https://docs.python.org/3/library/stdtypes.html#list.sort))
  - `dataset.batch(batch_size, drop_last=False)`: Batches `batch_size` examples together as a list. Usually followed by a map ([tensorflow.data.Dataset.batch](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#batch))
  - `dataset.random_choice()`: Get a random example ([numpy.random.choice](https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.choice.html))
+ - `dataset.cache()`: Cache in RAM (similar to ESPnet's `keep_all_data_on_mem`)
+ - `dataset.diskcache()`: Cache to a cache directory on the local filesystem (useful in clusters network slow filesystems)
  - ...
 
 

--- a/comparison/comparison.md
+++ b/comparison/comparison.md
@@ -19,6 +19,7 @@ from torch.utils.data import DataLoader as TorchDataLoader
 |    5    | Sort by value | yes | no |
 |    6    | Draw random example | yes | no |
 |    7    | Unbatch | yes | no |
+|         | Automatic caching (in RAM and on disk) | yes | no |
 
 ## Examples
 1. Dataset

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -2689,6 +2689,7 @@ class CacheDataset(Dataset):
             self._cache = _CacheWrapper(immutable_warranty)
 
         self._keep_mem_free = self._get_memory_size(keep_mem_free)
+        self._do_cache = True
 
     @property
     def indexable(self) -> bool:
@@ -2721,6 +2722,9 @@ class CacheDataset(Dataset):
         if self._keep_mem_free is None:
             return True
 
+        if not self._do_cache:
+            return False
+
         import psutil
         if psutil.virtual_memory().available <= self._keep_mem_free:
             # Return without writing to cache if there is not enough
@@ -2731,6 +2735,7 @@ class CacheDataset(Dataset):
                 'The remaining data will not be cached.',
                 ResourceWarning
             )
+            self._do_cache = False
             return False
         return True
 

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -2728,7 +2728,8 @@ class CacheDataset(Dataset):
             import warnings
             warnings.warn(
                 'Max capacity of the in-memory cache is reached. '
-                'The remaining data will not be cached.'
+                'The remaining data will not be cached.',
+                ResourceWarning
             )
             return False
         return True
@@ -2863,7 +2864,7 @@ class DiskCacheDataset(CacheDataset):
                 f'{humanfriendly.format_size(diskusage.total, binary=True)}'
                 f', free='
                 f'{humanfriendly.format_size(diskusage.free, binary=True)}'
-                f')'
+                f')', ResourceWarning
             )
             if diskusage.free < 1 * 1024 ** 3:
                 # Crash if less than 1GB left. It's better to crash

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -1294,7 +1294,8 @@ class Dataset:
 
         It is recommended to apply caching after data loading and before any
         data-multiplying transformations (e.g., STFT) are applied, e.g.,
-        `dataset.map(load_data).diskcache().map(transform)`.
+        `dataset.map(load_data).diskcache().map(transform)` to minimize the
+        cache size.
 
         Examples:
             >>> ds = new(list(range(10))).diskcache()
@@ -1323,7 +1324,7 @@ class Dataset:
                 SIGTERM, SIGKILL, SIGSEGV). Clearing on SIGTERM usually works
                 when the signal is handled somewhere in the python code and
                 fails otherwise (Adding
-                `signal.signal(signal.SIGTERM, lambda *X: exit(1))` makes the
+                `signal.signal(signal.SIGTERM, lambda *x: exit(1))` makes the
                 the clearing process work but might interfere with other parts
                 of the program than try to handle signals).
         """

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -2878,7 +2878,8 @@ class DiskCacheDataset(CacheDataset):
                 # this process than to crash the whole machine
                 raise RuntimeError(
                     f'Not enough space on device! The device that the '
-                    f'cache directory is located on has less than 1GB '
+                    f'cache directory "{self._cache.cache.directory}" '
+                    f'is located on has less than 1GB '
                     f'space left. You probably want to delete some '
                     f'files before crashing the machine.'
                 )

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -2744,13 +2744,14 @@ class CacheDataset(Dataset):
             item = self.keys().index(item)
 
         if isinstance(item, numbers.Integral):
-            if item in self._cache:
+            try:
                 value = self._cache[item]
-            else:
+            except KeyError:
                 value = self.input_dataset[item]
                 if self.check():
                     self._cache[item] = value
-            return value
+            finally:
+                return value
         else:
             # Support for slices etc.
             return super().__getitem__(item)

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -2796,7 +2796,8 @@ class _DiskCacheWrapper:
         self.clear = clear
 
         import diskcache
-        if cache_dir is not None and Path(cache_dir).is_dir():
+        if cache_dir is not None and Path(cache_dir).is_dir() and len(
+                list(Path(cache_dir).glob('*'))) > 0:
             if reuse:
                 print(f'Cache dir "{cache_dir}" already exists. Re-using '
                       f'stored data.')

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -1313,9 +1313,9 @@ class Dataset:
             >>> ds = new(list(range(10))).diskcache()
 
         Warnings:
-            Be careful to only enalbe this when you know that the data in
-            `cache_dir` is what you want! Otherwise this option can cause
-            hard-to-find bugs.
+            Be careful to only enalbe `resue` when you know that the data in
+            `cache_dir` is valid for your dataset! Otherwise this option
+            produces invalid outputs and hard-to-find bugs!
 
             This dataset is *not* immutable! It maintains the cache as an
             instance variable, possibly even across runs of your script (if
@@ -1324,8 +1324,6 @@ class Dataset:
             This dataset freezes everything that comes before this dataset!
             E.g., anything random before applying `.diskcache` is frozen. Any
             shuffling has to be applied after caching!
-
-            Make sure to delete unused cache directories!
 
         Args:
             cache_dir: Directory to save the cached data. If `None`, it uses
@@ -2674,7 +2672,6 @@ class DynamicBucketDataset(Dataset):
 class CacheDataset(Dataset):
     def __init__(self, input_dataset: Dataset, keep_mem_free=None,
                  immutable_warranty: str = 'pickle') -> None:
-        super().__init__()
         assert input_dataset.indexable, (
             'CacheDataset only works if dataset is indexable!'
         )
@@ -2809,8 +2806,8 @@ class _DiskCacheWrapper:
                       f'stored data.')
             else:
                 raise RuntimeError(
-                    f'Cache dir "{cache_dir}" exists! Either remove it '
-                    f'or set reuse=True.'
+                    f'Cache dir "{cache_dir}" already exists! Either remove '
+                    f'it or set reuse=True.'
                 )
         self.cache = diskcache.Cache(cache_dir)
 

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -2809,7 +2809,9 @@ class _DiskCacheWrapper:
                     f'Cache dir "{cache_dir}" already exists! Either remove '
                     f'it or set reuse=True.'
                 )
-        self.cache = diskcache.Cache(cache_dir)
+        # eviction_policy='none' deactivates the cache size limit (of 1GB by
+        # default)
+        self.cache = diskcache.Cache(cache_dir, eviction_policy='none')
 
     def __del__(self):
         # This gets called when all references to the cache wrapper are

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRED = [
 
 # What packages are optional?
 EXTRAS = {
-    'cache': ['humanfriendly', 'psutil'],
+    'cache': ['humanfriendly', 'psutil', 'diskcache'],
     # 'fancy feature': ['django'],
 }
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -58,13 +58,13 @@ def test_cache_mem_abs():
 
         available_mem = gb(6)
         it = iter(ds)
-        assert len(ds.cache) == 0
+        assert len(ds._cache) == 0
         next(it)
-        assert len(ds.cache) == 1
+        assert len(ds._cache) == 1
         available_mem = gb(5)
         with pytest.warns(UserWarning, match='Max capacity'):
             next(it)
-        assert len(ds.cache) == 1
+        assert len(ds._cache) == 1
 
 
 def test_cache_mem_percent():
@@ -82,13 +82,13 @@ def test_cache_mem_percent():
 
         available_mem = gb(9)
         it = iter(ds)
-        assert len(ds.cache) == 0
+        assert len(ds._cache) == 0
         next(it)
-        assert len(ds.cache) == 1
+        assert len(ds._cache) == 1
         available_mem = gb(7)
         with pytest.warns(UserWarning, match='Max capacity'):
             next(it)
-        assert len(ds.cache) == 1
+        assert len(ds._cache) == 1
 
 
 def test_cache_from_ordered_not_indexable():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -34,7 +34,9 @@ def test_cache_call_only_once():
         call_counter[x] += 1
         return x
 
-    dataset = dataset.map(m).cache()
+    # Set keep_mem_free to a small value to allow testing on machines with
+    # less RAM
+    dataset = dataset.map(m).cache(keep_mem_free='1GB')
     for _ in dataset:
         pass
     assert all(v == 1 for v in call_counter.values())
@@ -63,7 +65,7 @@ def test_cache_mem_abs():
         next(it)
         assert len(ds._cache) == 1
         available_mem = gb(5)
-        with pytest.warns(UserWarning, match='Max capacity'):
+        with pytest.warns(ResourceWarning, match='Max capacity'):
             next(it)
         assert len(ds._cache) == 1
 
@@ -87,7 +89,7 @@ def test_cache_mem_percent():
         next(it)
         assert len(ds._cache) == 1
         available_mem = gb(7)
-        with pytest.warns(UserWarning, match='Max capacity'):
+        with pytest.warns(ResourceWarning, match='Max capacity'):
             next(it)
         assert len(ds._cache) == 1
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,8 @@
+import tempfile
 from collections import Counter
+from pathlib import Path
 
 import lazy_dataset
-import numpy as np
 import psutil
 import mock
 import pytest
@@ -99,3 +100,81 @@ def test_cache_from_ordered_not_indexable():
 def test_cache_no_keys():
     ds = lazy_dataset.new(list(range(100))).cache()
     assert list(ds) == list(range(100))
+
+
+def test_diskcache_immutable():
+    dataset = lazy_dataset.new({
+        'a': {'value': 1},
+        'b': {'value': 2},
+        'c': {'value': 3},
+    })
+
+    cached_dataset = dataset.diskcache()
+
+    assert cached_dataset['a']['value'] == 1
+    cached_dataset['a']['value'] = 42
+    assert cached_dataset['a']['value'] == 1
+
+
+def test_diskcache_call_only_once():
+    call_counter = Counter()
+    dataset = lazy_dataset.new(dict(zip(map(str, range(10)), range(10))))
+
+    def m(x):
+        call_counter[x] += 1
+        return x
+
+    dataset = dataset.map(m).diskcache()
+    for _ in dataset:
+        pass
+    assert all(v == 1 for v in call_counter.values())
+    for _ in dataset:
+        pass
+    assert all(v == 1 for v in call_counter.values())
+
+
+def test_diskcache_clear():
+    dataset = lazy_dataset.new(list(range(10)))
+    cache_dir = tempfile.mkdtemp()
+
+    dataset = dataset.diskcache(cache_dir=cache_dir, clear=True)
+    list(dataset)
+    assert Path(cache_dir).is_dir()
+    del(dataset)
+    assert not Path(cache_dir).exists()
+
+
+def test_diskcache_reuse():
+    with tempfile.TemporaryDirectory() as cache_dir:
+        # Create dataset and write to cache
+        dataset = lazy_dataset.new(list(range(10))).diskcache(
+            cache_dir=cache_dir, reuse=True, clear=False)
+        list(dataset)
+        del dataset
+
+        # Assert that the cache didn't get deleted
+        assert Path(cache_dir).exists()
+
+        # Create a new dataset with the same cache dir and assert that the data
+        # gets loaded from the cache and not from the data pipeline
+        call_counter = 0
+
+        def _count_calls(x):
+            nonlocal call_counter
+            call_counter += 1
+            return x
+
+        dataset = (lazy_dataset.new(list(range(10)))
+            .map(_count_calls)
+            .diskcache(cache_dir=cache_dir, reuse=True, clear=False))
+        list(dataset)
+
+        assert call_counter == 0
+
+
+def test_diskcache_raise_if_cache_exists():
+    with tempfile.TemporaryDirectory() as cache_dir:
+        (Path(cache_dir) / 'file').touch()
+        with pytest.raises(RuntimeError):
+            lazy_dataset.new(list(range(10))).diskcache(
+                cache_dir=cache_dir, reuse=False)


### PR DESCRIPTION
Adds ability to cache computation on the local filesystem. Usage example: `dataset.diskcache('/tmp/cache')`. Open points:
 - Good thresholds for warning when disk space get scarce
 - How to make sure that the cache is cleared when `clear=True` and the experiment crashes