### PR TITLE
Fix indexable property of BatchDataset

### DIFF
--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -3071,7 +3071,7 @@ class BatchDataset(Dataset):
 
     @property
     def indexable(self):
-        return self.input_dataset.input_dataset
+        return self.input_dataset.indexable
 
     @property
     def ordered(self) -> bool:


### PR DESCRIPTION
The `indexable` property of `BatchDataset` currently returns a `Dataset` instance which always evaluates to True. Changed to return the `indexable` property of the incoming dataset as is done in other dataset classes.