### PR TITLE
Add terminate to perfetch on GeneratorExit

### DIFF
--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -636,9 +636,10 @@ class Dataset:
 
             # When using only some examples from the dataset,
             # multiple examples will be precalculated.
-            # Here: Up to "called with 3" could be executed, but here
-            #       typically only up to "called with 2" is calculated.
-            >>> next(iter(ds))  # doctest: +ELLIPSIS
+            # Here: Up to "called with 3" could be executed.
+            #       Typically only up to "called with 2" is calculated,
+            #       but this varies between 1 and 3, hence disable test.
+            >>> next(iter(ds))  # doctest: +SKIP
             called with 0
             called with 1
             called with 2

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -633,11 +633,15 @@ class Dataset:
             called with 9
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
             >>> ds = ds.prefetch(2, 4)
-            >>> next(iter(ds))
+
+            # When using only some examples from the dataset,
+            # multiple examples will be precalculated.
+            # Here: Up to "called with 3" could be executed, but here
+            #       typically only up to "called with 2" is calculated.
+            >>> next(iter(ds))  # doctest: +ELLIPSIS
             called with 0
             called with 1
             called with 2
-            called with 3
             0
 
             # A second prefetch with multiple workes does not work, but a

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -3638,7 +3638,6 @@ class _DiskCacheWrapper:
             if reuse:
                 LOG.info(f'Cache dir "{cache_dir}" already exists. Re-using stored data.')
             else:
-                self.cache = None
                 raise RuntimeError(
                     f'Cache dir "{cache_dir}" already exists! Either remove '
                     f'it or set reuse=True.'
@@ -3668,7 +3667,7 @@ class _DiskCacheWrapper:
 
         # When the __init__ raises a RuntimeError, the instance has no
         # cache attribute.
-        if self.cache is not None:
+        if hasattr(self, 'cache'):
             self.cache.close()
             if self.clear:
                 if Path(self.cache.directory).exists():

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -3637,6 +3637,7 @@ class _DiskCacheWrapper:
             if reuse:
                 LOG.info(f'Cache dir "{cache_dir}" already exists. Re-using stored data.')
             else:
+                self.cache = None
                 raise RuntimeError(
                     f'Cache dir "{cache_dir}" already exists! Either remove '
                     f'it or set reuse=True.'
@@ -3663,11 +3664,15 @@ class _DiskCacheWrapper:
         # termination and keyboard interrupt, but no other signals like
         # SIGTERM or SIGKILL. Some signals sometimes work if they are handled
         # within python.
-        self.cache.close()
-        if self.clear:
-            if Path(self.cache.directory).exists():
-                import shutil
-                shutil.rmtree(self.cache.directory)
+
+        # When the __init__ raises a RuntimeError, the instance has no
+        # cache attribute.
+        if self.cache is not None:
+            self.cache.close()
+            if self.clear:
+                if Path(self.cache.directory).exists():
+                    import shutil
+                    shutil.rmtree(self.cache.directory)
 
 
 class DiskCacheDataset(CacheDataset):

--- a/lazy_dataset/parallel_utils.py
+++ b/lazy_dataset/parallel_utils.py
@@ -2,6 +2,7 @@ import queue
 import concurrent.futures
 import os
 import sys
+import contextlib
 import threading
 from typing import Iterable, Optional
 
@@ -123,13 +124,39 @@ def lazy_parallel_map(
     if backend == "mp":
         # http://stackoverflow.com/a/21345423
         from pathos.multiprocessing import ProcessPool as PathosPool
+        import pathos.helpers.pp_helper
         PoolExecutor = PathosPool
 
         def submit(ex, func, *args, **kwargs):
             return ex.apipe(func, *args, **kwargs)
 
+        def result(job: pathos.helpers.pp_helper.ApplyResult):
+            return job.get()
+
+        def terminate(ex: pathos.multiprocessing.ProcessPool, q):
+            ex.terminate()
+            # Cancel doesn't work for pathos. Don't know why.
+            # try:
+            #     while True:
+            #         q.get(block=False).cancel()
+            # except queue.Empty:
+            #     pass
+
+    elif backend == 'multiprocessing':
+        from multiprocessing import Pool as PoolExecutor
+
+        def submit(ex, func, *args, **kwargs):
+            return ex.apply_async(func, args, kwargs)
+
         def result(job):
             return job.get()
+
+        def terminate(ex, q):
+            try:
+                while True:
+                    q.get(block=False).cancel()
+            except queue.Empty:
+                pass
 
     elif backend == "dill_mp":
         import dill
@@ -144,10 +171,17 @@ def lazy_parallel_map(
         def result(job):
             return job.result()
 
+        def terminate(ex: concurrent.futures.Executor, q):
+            try:
+                while True:
+                    q.get(block=False).cancel()
+            except queue.Empty:
+                pass
+
     elif backend in [
             "t",
             "thread",
-            "concurrent_mp"
+            "concurrent_mp",
     ]:
         if backend in ['t', 'thread']:
             PoolExecutor = concurrent.futures.ThreadPoolExecutor
@@ -160,31 +194,57 @@ def lazy_parallel_map(
         def submit(ex, func, *args, **kwargs):
             return ex.submit(func, *args, **kwargs)
 
-        def result(job):
+        def result(job: concurrent.futures.Future):
             return job.result()
-    # elif backend is False:
-    #
-    #     @contextmanager
-    #     def PoolExecutor(max_workers):
-    #         yield None
-    #
-    #     def submit(ex, func, *args, **kwargs):
-    #         return func(*args, **kwargs)
-    #
-    #     def result(job):
-    #         return job
+
+        def terminate(ex: concurrent.futures.Executor, q):
+            # shutdown doesn't work for threads. Don't know why.
+            # For mp shutdown doesn't work and the processes keep the
+            # program alive, i.e. it never stops properly.
+            # Hence, use cancel for both.
+            # ex.shutdown(wait=False)
+
+            try:
+                while True:
+                    q.get(block=False).cancel()
+            except queue.Empty:
+                pass
+
+    elif backend is False:
+
+        @contextlib.contextmanager
+        def PoolExecutor(max_workers):
+            yield None
+
+        def submit(ex, func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        def result(job):
+            return job
+
+        def terminate(ex, q):
+            pass
+
     else:
         raise ValueError(backend)
 
     with PoolExecutor(max_workers) as executor:
-        # First fill the buffer
-        # If buffer full, take one element and push one new inside
-        for ele in generator:
-            if q.qsize() >= buffer_size:
+        try:
+            # First fill the buffer
+            # If buffer full, take one element and push one new inside
+            for ele in generator:
+                if q.qsize() >= buffer_size:
+                    yield result(q.get())
+                q.put(submit(executor, function, ele, *args, **kwargs))
+            while not q.empty():
                 yield result(q.get())
-            q.put(submit(executor, function, ele, *args, **kwargs))
-        while not q.empty():
-            yield result(q.get())
+        except GeneratorExit:
+            # A GeneratorExit will not stop the PoolExecutor,
+            # i.e. the PoolExecutor will finish all calculations,
+            # before the PoolExecutor stops. This could take some time
+            # and is useless.
+            terminate(executor, q)
+            raise
 
 
 def single_thread_prefetch(

--- a/lazy_dataset/parallel_utils.py
+++ b/lazy_dataset/parallel_utils.py
@@ -224,6 +224,7 @@ def lazy_parallel_map(
             # ToDo: Changed in python version 3.9: Added cancel_futures.
             #  - Use ex.shutdown(`cancel_futures`), once we drop support for
             #    python 3.8.
+            #  - Once it is used, check that shutdown for mp has no deadlock.
 
             try:
                 while True:

--- a/lazy_dataset/parallel_utils.py
+++ b/lazy_dataset/parallel_utils.py
@@ -152,11 +152,14 @@ def lazy_parallel_map(
             return job.get()
 
         def terminate(ex, q):
-            try:
-                while True:
-                    q.get(block=False).cancel()
-            except queue.Empty:
-                pass
+            # It looks like multiprocessing works fine with GeneratorExit
+            # and no "hack" is necessary to fix it.
+            pass
+            # try:
+            #     while True:
+            #         q.get(block=False).cancel()
+            # except queue.Empty:
+            #     pass
 
     elif backend == "dill_mp":
         import dill

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ REQUIRED = [
 # What packages are optional?
 EXTRAS = {
     'cache': ['humanfriendly', 'psutil', 'diskcache'],
-    'test': ['mock'],
+    'test': [
+        'mock',
+        'dill',  # special backend for prefetch
+        'pathos',  # special backend for prefetch
+    ],
     'cli': ['IPython', 'paderbox'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,17 @@ EXTRAS = {
         'dill',  # special backend for prefetch
         'pathos',  # special backend for prefetch
     ],
-    'cli': ['IPython', 'paderbox'],
+    'cli': [
+        # When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
+        # Python 3.3 and 3.4 were supported up to IPython 6.x.
+        # Python 3.5 was supported with IPython 7.0 to 7.9.
+        # Python 3.6 was supported with IPython up to 7.16.
+        # Python 3.7 was still supported with the 7.x branch.
+        "IPython<8.0; python_version=='3.7'",  # IPython 8.0-8.12 supports Python 3.8 and above, following NEP 29.
+        "IPython<8.13.0; python_version=='3.8'",  # IPython 8.13+ supports Python 3.9 and above, following NEP 29.
+        "IPython; python_version>='3.9'",
+        'paderbox',
+    ],
 }
 
 # The rest you shouldn't have to touch too much :)

--- a/tests/test_parallel_utils.py
+++ b/tests/test_parallel_utils.py
@@ -89,7 +89,7 @@ class Foo:
 
 @pytest.mark.parametrize("backend,sleep,thresh", [
     ['t', 0.01, 5],
-    ['mp', 0.01, 15],
+    ['mp', 0.01, 19],
     ['dill_mp', 0.01, 12],
     ['multiprocessing', 0.01, 5],
     ['concurrent_mp', 0.01, 8],

--- a/tests/test_parallel_utils.py
+++ b/tests/test_parallel_utils.py
@@ -1,0 +1,119 @@
+import functools
+import operator
+from pathlib import Path
+import pytest
+import lazy_dataset
+import time
+
+
+@pytest.mark.parametrize("backend,func", [
+    ['t', 'global'],
+    ['t', 'local'],
+    ['t', 'partial'],
+    ['t', 'lambda'],
+    ['mp', 'global'],
+    ['mp', 'local'],
+    # ['mp', 'partial'],  # AttributeError: 'functools.partial' object has no attribute '__module__'
+    ['mp', 'lambda'],
+    ['dill_mp', 'global'],
+    ['dill_mp', 'local'],
+    # ['dill_mp', 'partial'],  # AttributeError: 'functools.partial' object has no attribute '__module__'
+    ['dill_mp', 'lambda'],
+    ['multiprocessing', 'global'],
+    # ['multiprocessing', 'local'],  # AttributeError: Can't pickle local object 'test_prefetch.<locals>.foo'
+    ['multiprocessing', 'partial'],
+    # ['multiprocessing', 'lambda'],  # AttributeError: Can't pickle local object 'test_prefetch.<locals>.<lambda>'
+    ['concurrent_mp', 'global'],
+    # ['concurrent_mp', 'local'],  # ToDO: Fix deadlock to exception
+    ['concurrent_mp', 'partial'],
+    # ['concurrent_mp', 'lambda'],  # ToDO: Fix deadlock to exception
+])
+def test_prefetch(backend, func):
+    if func == 'local':
+        def foo(x):
+            return x + 2
+    elif func == 'global':
+        foo = operator.neg
+    elif func == 'partial':
+        foo = functools.partial(operator.add, 2)
+    elif func == 'lambda':
+        foo = lambda x: x+2
+    else:
+        raise ValueError(func)
+
+    ds = lazy_dataset.from_list(list(range(100)))
+    ds = ds.map(foo)
+
+    ds = ds.prefetch(2, 50, backend=backend)
+
+    for ex in ds:
+        pass
+
+
+def test_break_threads():
+    # This test tests a bug from the past:
+    # lazy_parallel_map finished all calculations in the buffer, when
+    # it received a GeneratorExit.
+
+    data = []
+    def foo(ex):
+        # Some delay to prevent an immediate full buffer.
+        # time.sleep releases the GIL.
+        time.sleep(0.01)
+        data.append(ex)
+        return ex
+
+    ds = lazy_dataset.from_list(list(range(100)))
+    ds = ds.map(foo)
+
+    ds = ds.prefetch(2, 50, backend='t')
+
+    for ex in ds:
+        break
+
+    assert 1 <= len(data) <= 5, (len(data), data)
+
+
+class Foo:
+    def __init__(self, tmpdir, sleep):
+        self.tmpdir = tmpdir
+        self.sleep = sleep
+
+    def __call__(self, ex):
+        # Some delay to prevent an immediate full buffer.
+        # time.sleep releases the GIL.
+        time.sleep(self.sleep)
+        (self.tmpdir / f'{ex}.txt').touch()
+        return ex
+
+
+@pytest.mark.parametrize("backend,sleep,thresh", [
+    ['t', 0.01, 5],
+    ['mp', 0.01, 15],
+    ['dill_mp', 0.01, 12],
+    ['multiprocessing', 0.01, 5],
+    ['concurrent_mp', 0.01, 8],
+])
+def test_break_backend(backend, sleep, thresh):
+    # This test tests a bug from the past:
+    # lazy_parallel_map finished all calculations in the buffer, when
+    # it received a GeneratorExit.
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        ds = lazy_dataset.from_list(list(range(100)))
+        ds = ds.map(Foo(tmpdir, sleep))
+
+        # Note: This test assumes a thread backend and also works only with
+        # threads.
+        ds = ds.prefetch(2, 50, backend=backend)
+
+        for ex in ds:
+            break
+        time.sleep(1)
+        data = list(tmpdir.glob('*'))
+
+        assert 1 <= len(data) <= thresh, (backend, len(data), data)


### PR DESCRIPTION
By default, pools finish all their tasks (i.e. fill the buffer), before they shut down. Hence, added a terminate to the code.
Depending on the backend, it cancels tasks or terminates the backend. It is not perfect, but better than the current behavior.

Added tests to check that the changes work.

Documented in the test, that concurrent_mp can produce deadlocks, while it should fail / raise an exception.