### PR TITLE
Fix items bug of dataset that doesn't support items

### DIFF
--- a/.github/workflows/run_python_tests.yml
+++ b/.github/workflows/run_python_tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/lazy_dataset/__init__.py
+++ b/lazy_dataset/__init__.py
@@ -1,3 +1,4 @@
+from . import core
 from .core import (
     new,
     concatenate,
@@ -7,6 +8,7 @@ from .core import (
     from_dict,
     from_list,
     from_dataset,
+    from_file,
     FilterException,
 )
-from.core import _zip as zip
+from .core import _zip as zip

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -214,7 +214,6 @@ def from_dataset(
         >>> from_dataset(ds)
           ListDataset(len=4)
         MapDataset(_pickle.loads)
-        >>> list(ds.items())
 
     """
     try:
@@ -434,7 +433,10 @@ class Dataset:
         Returns:
             A copy of this dataset
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            f'copy is not implemented for {self.__class__}.\n'
+            f'self: \n{repr(self)}'
+        )
 
     def __iter__(self, with_key=False):
         if with_key:
@@ -2706,8 +2708,8 @@ class ConcatenateDataset(Dataset):
         if with_key:
             try:
                 self.keys()
-            except AssertionError:
-                raise _ItemsNotDefined(self.__class__.__name__) from None
+            except AssertionError as e:
+                raise _ItemsNotDefined(self.__class__.__name__) from e
 
         for input_dataset in self.input_datasets:
             if with_key:
@@ -2996,6 +2998,7 @@ class KeyZipDataset(Dataset):
             ]
             raise AssertionError(
                 f'Expect that all input_datasets have the same keys. '
+                f'Missing: {lengths} of {len(keys)}\n'
                 f'Missing keys: '
                 f'{missing_keys}\n{self.input_datasets}'
             )

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -201,6 +201,21 @@ def from_dataset(
         >>> ds = from_dataset(new({'a': 1, 'b': 2, 'c': 3, 'd': 4}).filter(lambda x: x%2))
         >>> dict(ds)
         {'a': 1, 'c': 3}
+
+        # Works with concatenated datasets and duplicated keys
+        >>> ds = new({'a': 1, 'b': 2})
+        >>> ds = concatenate(ds, ds)
+        >>> ds
+            DictDataset(len=2)
+          MapDataset(_pickle.loads)
+            DictDataset(len=2)
+          MapDataset(_pickle.loads)
+        ConcatenateDataset()
+        >>> from_dataset(ds)
+          ListDataset(len=4)
+        MapDataset(_pickle.loads)
+        >>> list(ds.items())
+
     """
     try:
         items = list(examples.items())
@@ -208,7 +223,9 @@ def from_dataset(
         return from_list(list(examples),
                          immutable_warranty=immutable_warranty, name=name)
     else:
-        return from_dict(dict(items),
+        new = dict(items)
+        assert len(new) == len(items), f'{len(new)} != {len(items)}\nYou found a bug!\n{examples!r}'
+        return from_dict(new,
                          immutable_warranty=immutable_warranty, name=name)
 
 

--- a/lazy_dataset/core.py
+++ b/lazy_dataset/core.py
@@ -2703,6 +2703,12 @@ class ConcatenateDataset(Dataset):
         return all(ds.ordered for ds in self.input_datasets)
 
     def __iter__(self, with_key=False):
+        if with_key:
+            try:
+                self.keys()
+            except AssertionError:
+                raise _ItemsNotDefined(self.__class__.__name__) from None
+
         for input_dataset in self.input_datasets:
             if with_key:
                 iterable = input_dataset.__iter__(with_key=True)


### PR DESCRIPTION
Fix for `cache`, `from_dataset` and `new` to work properly with input datasets, that have no support for keys, because they are duplicated.

The issue was, that duplicates were dropped:
 - `list(ds.items())` worked and created a list of key values pairs
 - `dict(list(ds.items()))` removed duplicated keys.

Now the code checks, that no examples get lost and concatenate is fixed to raise an exception, when items is called, while some keys are duplicated.

